### PR TITLE
feat: add Tesla profiles to bil calc

### DIFF
--- a/single-page-htmls/swedish-foretag-bil-calc.html
+++ b/single-page-htmls/swedish-foretag-bil-calc.html
@@ -32,6 +32,7 @@
     p { margin: 0 0 10px; color: var(--muted); }
     .grid { display: grid; grid-template-columns: 1fr 1fr; gap: 18px; }
     .three { display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; }
+    .four { display: grid; grid-template-columns: repeat(4, 1fr); gap: 14px; }
     .card {
       background: var(--card);
       border: 1px solid var(--border);
@@ -42,8 +43,9 @@
     .input-row { display: grid; grid-template-columns: 1.1fr 1fr; align-items: center; gap: 12px; margin: 12px 0; }
     label { font-weight: 600; font-size: 14px; }
     .hint { display: block; font-weight: 400; font-size: 12px; color: var(--muted); margin-top: 2px; }
-    input[type="number"] {
+    input[type="number"], select {
       width: 100%; padding: 10px 12px; border-radius: 10px; border: 1px solid var(--border); font-size: 15px;
+      background: #fff;
     }
     input[type="range"] { width: 100%; }
     .slider-row { margin: 16px 0 6px; }
@@ -68,7 +70,7 @@
     .bar { height: 100%; background: var(--accent); border-radius: 999px; transition: width .15s ease; }
     .footer-note { margin-top: 18px; font-size: 12px; color: var(--muted); }
     @media (max-width: 900px) {
-      .grid, .three { grid-template-columns: 1fr; }
+      .grid, .three, .four { grid-template-columns: 1fr; }
       .input-row { grid-template-columns: 1fr; }
     }
     @media print {
@@ -88,6 +90,7 @@
     <div class="grid">
       <section class="card">
         <h2>Editable assumptions</h2>
+        <div class="input-row"><label>Car profile <span class="hint">Pre-fill lease fee and förmånsvärde</span></label><select id="carProfile"></select></div>
         <div class="input-row"><label>Gross salary before change (bruttolön) <span class="hint">Current base salary</span></label><input id="salary" type="number" value="40000" step="100" /></div>
         <div class="input-row"><label>Salary reduction (lönereduktion) <span class="hint">Example: reduce 40k → 37k means 3,000</span></label><input id="salaryReduction" type="number" value="0" step="100" /></div>
         <div class="input-row"><label>Monthly lease ex VAT (leasing ex moms) <span class="hint">Tesla quoted lease before VAT</span></label><input id="leaseExVat" type="number" value="4857" step="50" /></div>
@@ -113,10 +116,16 @@
           <input id="salaryReductionSlider" type="range" min="0" max="10000" value="0" step="100" />
         </div>
 
-        <div class="section three">
+        <div class="section four">
           <div class="metric"><div class="label">Company net monthly cost (nettokostnad för bolaget)</div><div class="value bad" id="companyCost"></div></div>
+          <div class="metric"><div class="label">Company net annual cost (årskostnad för bolaget)</div><div class="value bad" id="companyAnnualCost"></div></div>
           <div class="metric"><div class="label">Personal monthly cash impact (personlig kassaflödespåverkan)</div><div class="value" id="personalImpact"></div></div>
           <div class="metric"><div class="label">Remaining taxable benefit (kvarvarande skattepliktig förmån)</div><div class="value warn" id="taxableBenefit"></div></div>
+        </div>
+        <div class="section three">
+          <div class="metric"><div class="label">Estimated net salary before (nettolön före)</div><div class="value" id="netSalaryBefore"></div></div>
+          <div class="metric"><div class="label">Estimated net salary after deductions (nettolön efter avdrag)</div><div class="value" id="netSalaryAfter"></div></div>
+          <div class="metric"><div class="label">Monthly net salary change</div><div class="value" id="netSalaryChange"></div></div>
         </div>
 
         <div class="section card" style="box-shadow:none;padding:14px;background:#fbfdff;">
@@ -148,7 +157,7 @@
     <section class="card section">
       <h2>Comparison presets</h2>
       <table>
-        <thead><tr><th>Scenario</th><th>Company net cost / month</th><th>Personal cash impact / month</th><th>Remaining taxable benefit</th></tr></thead>
+        <thead><tr><th>Scenario</th><th>Company net cost / month</th><th>Company net cost / year</th><th>Personal cash impact / month</th><th>Remaining taxable benefit</th></tr></thead>
         <tbody id="comparison"></tbody>
       </table>
       <p class="footer-note">Personal impact is compared with keeping the old Golf and paying the old monthly cost privately. Positive means better personal cashflow; negative means worse personal cashflow.</p>
@@ -170,8 +179,23 @@
 <script>
 const ids = ["salary","salaryReduction","leaseExVat","benefit","netDeduction","oldCarCost","insurance","maintenance","fuelSaving","personalTax","employerFee","corpTax"];
 const el = Object.fromEntries(ids.map(id => [id, document.getElementById(id)]));
+const carProfiles = [
+  { name: 'Tesla Model 3 RWD', leaseExVat: 4857, benefit: 4748 },
+  { name: 'Tesla Model 3 Long Range RWD', leaseExVat: 5797, benefit: 5340 },
+  { name: 'Tesla Model Y RWD', leaseExVat: 4857, benefit: 5077 },
+  { name: 'Tesla Model Y Long Range RWD', leaseExVat: 6663, benefit: 5820 }
+];
 const fmt = n => new Intl.NumberFormat('sv-SE', { maximumFractionDigits: 0 }).format(Math.round(n)) + ' kr';
 const pct = n => Number(n) / 100;
+function setupCarProfiles() {
+  const select = document.getElementById('carProfile');
+  select.innerHTML = carProfiles.map((profile, index) => `<option value="${index}">${profile.name}</option>`).join('');
+  select.value = '0';
+}
+function selectedCarProfileName() {
+  const profile = carProfiles[Number(document.getElementById('carProfile').value)];
+  return profile ? profile.name : 'custom car';
+}
 function values(override = {}) {
   const v = Object.fromEntries(ids.map(id => [id, parseFloat(el[id].value || 0)]));
   return { ...v, ...override };
@@ -188,10 +212,14 @@ function calc(v) {
   const companyBeforeCorpTax = grossCarCost + employerFeeOnBenefit - v.netDeduction - salarySavingForCompany;
   const corpTaxShield = Math.max(0, companyBeforeCorpTax) * pct(v.corpTax);
   const companyAfterCorpTax = companyBeforeCorpTax - corpTaxShield;
+  const companyAnnualCost = companyAfterCorpTax * 12;
   const personalTaxOnBenefit = taxableBenefit * pct(v.personalTax);
   const netSalaryLossFromReduction = v.salaryReduction * (1 - pct(v.personalTax));
+  const netSalaryBefore = v.salary * (1 - pct(v.personalTax));
+  const netSalaryAfter = (v.salary - v.salaryReduction) * (1 - pct(v.personalTax)) - v.netDeduction - personalTaxOnBenefit;
+  const netSalaryChange = netSalaryAfter - netSalaryBefore;
   const personalImpact = v.oldCarCost + v.fuelSaving - v.netDeduction - personalTaxOnBenefit - netSalaryLossFromReduction;
-  return { vatOnLease, recoverableVat, leaseCashInclVat, effectiveLeaseCost, grossCarCost, taxableBenefit, employerFeeOnBenefit, salarySavingForCompany, companyBeforeCorpTax, corpTaxShield, companyAfterCorpTax, personalTaxOnBenefit, netSalaryLossFromReduction, personalImpact };
+  return { vatOnLease, recoverableVat, leaseCashInclVat, effectiveLeaseCost, grossCarCost, taxableBenefit, employerFeeOnBenefit, salarySavingForCompany, companyBeforeCorpTax, corpTaxShield, companyAfterCorpTax, companyAnnualCost, personalTaxOnBenefit, netSalaryLossFromReduction, netSalaryBefore, netSalaryAfter, netSalaryChange, personalImpact };
 }
 function setClass(node, val, positiveGood = true) {
   node.className = 'value ' + ((val >= 0) === positiveGood ? 'good' : 'bad');
@@ -207,10 +235,15 @@ function update() {
   const v = values();
   const r = calc(v);
   document.getElementById('companyCost').textContent = fmt(r.companyAfterCorpTax);
+  document.getElementById('companyAnnualCost').textContent = fmt(r.companyAnnualCost);
   document.getElementById('personalImpact').textContent = (r.personalImpact >= 0 ? '+' : '') + fmt(r.personalImpact);
   setClass(document.getElementById('personalImpact'), r.personalImpact, true);
   document.getElementById('taxableBenefit').textContent = fmt(r.taxableBenefit);
-  document.getElementById('plainResult').textContent = `With ${fmt(v.netDeduction)} nettolöneavdrag and ${fmt(v.salaryReduction)} salary reduction, the company carries about ${fmt(r.companyAfterCorpTax)} per month after estimated corporate tax effect. Your personal cashflow changes by about ${(r.personalImpact >= 0 ? '+' : '') + fmt(r.personalImpact)} per month compared with keeping the old car.`;
+  document.getElementById('netSalaryBefore').textContent = fmt(r.netSalaryBefore);
+  document.getElementById('netSalaryAfter').textContent = fmt(r.netSalaryAfter);
+  document.getElementById('netSalaryChange').textContent = (r.netSalaryChange >= 0 ? '+' : '') + fmt(r.netSalaryChange);
+  setClass(document.getElementById('netSalaryChange'), r.netSalaryChange, true);
+  document.getElementById('plainResult').textContent = `For ${selectedCarProfileName()}, with ${fmt(v.netDeduction)} nettolöneavdrag and ${fmt(v.salaryReduction)} salary reduction, the company carries about ${fmt(r.companyAfterCorpTax)} per month / ${fmt(r.companyAnnualCost)} per year after estimated corporate tax effect. Your estimated net salary after deductions is ${fmt(r.netSalaryAfter)}, and personal cashflow changes by about ${(r.personalImpact >= 0 ? '+' : '') + fmt(r.personalImpact)} per month compared with keeping the old car.`;
   const companyPct = Math.min(100, Math.max(0, r.companyAfterCorpTax / Math.max(1, r.grossCarCost + r.employerFeeOnBenefit) * 100));
   const benefitPct = Math.min(100, Math.max(0, r.taxableBenefit / Math.max(1, v.benefit) * 100));
   document.getElementById('companyBar').style.width = companyPct + '%';
@@ -238,10 +271,18 @@ function update() {
   ];
   document.getElementById('comparison').innerHTML = scenarios.map(([name, o]) => {
     const rr = calc(values(o));
-    return `<tr><td>${name}</td><td>${fmt(rr.companyAfterCorpTax)}</td><td>${rr.personalImpact >= 0 ? '+' : ''}${fmt(rr.personalImpact)}</td><td>${fmt(rr.taxableBenefit)}</td></tr>`;
+    return `<tr><td>${name}</td><td>${fmt(rr.companyAfterCorpTax)}</td><td>${fmt(rr.companyAnnualCost)}</td><td>${rr.personalImpact >= 0 ? '+' : ''}${fmt(rr.personalImpact)}</td><td>${fmt(rr.taxableBenefit)}</td></tr>`;
   }).join('');
 }
+setupCarProfiles();
 ids.forEach(id => el[id].addEventListener('input', update));
+document.getElementById('carProfile').addEventListener('change', e => {
+  const profile = carProfiles[Number(e.target.value)];
+  if (!profile) return;
+  el.leaseExVat.value = profile.leaseExVat;
+  el.benefit.value = profile.benefit;
+  update();
+});
 document.getElementById('netDeductionSlider').addEventListener('input', e => { el.netDeduction.value = e.target.value; update(); });
 document.getElementById('salaryReductionSlider').addEventListener('input', e => { el.salaryReduction.value = e.target.value; update(); });
 update();

--- a/single-page-htmls/swedish-foretag-bil-calc.html
+++ b/single-page-htmls/swedish-foretag-bil-calc.html
@@ -189,7 +189,7 @@ const fmt = n => new Intl.NumberFormat('sv-SE', { maximumFractionDigits: 0 }).fo
 const pct = n => Number(n) / 100;
 function setupCarProfiles() {
   const select = document.getElementById('carProfile');
-  select.innerHTML = carProfiles.map((profile, index) => `<option value="${index}">${profile.name}</option>`).join('');
+  select.innerHTML = '<option value="custom">Custom car</option>' + carProfiles.map((profile, index) => `<option value="${index}">${profile.name}</option>`).join('');
   select.value = '0';
 }
 function selectedCarProfileName() {
@@ -275,7 +275,10 @@ function update() {
   }).join('');
 }
 setupCarProfiles();
-ids.forEach(id => el[id].addEventListener('input', update));
+ids.forEach(id => el[id].addEventListener('input', () => {
+  if (id === 'leaseExVat' || id === 'benefit') document.getElementById('carProfile').value = 'custom';
+  update();
+}));
 document.getElementById('carProfile').addEventListener('change', e => {
   const profile = carProfiles[Number(e.target.value)];
   if (!profile) return;


### PR DESCRIPTION
## Summary
- Adds selectable Tesla profiles that pre-fill lease ex VAT and förmånsvärde values.
- Shows estimated net salary before/after deductions and monthly net salary change.
- Adds annual company cost alongside monthly company cost.

## Changes
- Added four Tesla profile presets for Model 3/Y RWD and Long Range RWD variants.
- Preserved taxable benefit logic so nettolöneavdrag reduces the benefit while salary reduction does not.
- Added annual company cost to summary metrics and comparison presets.
- Marks lease/benefit edits as a custom car profile to avoid misleading labels.

## Verification
- Ran a Node-based syntax and DOM id reference check for the embedded calculator script.
- Ran a focused code review; no blocking issues found.